### PR TITLE
Readme description update and release on event update

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,8 @@ on:
       - closed
     branches:
       - main
+    paths:
+      - action.yaml
 jobs:
   release-action:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <!-- end title -->
 <!-- start description -->
 
-Builds and pushes an image to a registry in a managed fashion
+Builds and pushes an image to a registry in a managed fashion for internal use
 
 <!-- end description -->
 <!-- start contents -->


### PR DESCRIPTION
Description now mentions "for internal use"
No longer runs release flow unless action is updated.