### PR TITLE
Fix add checkout

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,8 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Checkout (for sub-dirs)
+      uses: actions/checkout@v3
     - name: Build and push image to ECR
       uses: catalystsquad/action-build-push-image-ecr@v1
       with:

--- a/action.yaml
+++ b/action.yaml
@@ -25,7 +25,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Checkout (for sub-dirs)
+    - name: Checkout (for sub-dirs) # See warning in this section of underlying docker build action documentation https://github.com/docker/build-push-action#git-context
       uses: actions/checkout@v3
     - name: Build and push image to ECR
       uses: catalystsquad/action-build-push-image-ecr@v1


### PR DESCRIPTION
The docker build-push-action does not support sub directories at this time. So you need to do a checkout. The warning is about halfway down this section of the docs:
[https://github.com/docker/build-push-action#git-context](https://github.com/docker/build-push-action#git-context)

This was tested by using a checkout before calling this managed action. It's being added here because I want to have the managed action manage it.

For PA-68