### PR TITLE
fix: use new subaction

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,12 @@
 name: Release
-on: [push]
-  # pull_request:
-  #   types:
-  #     - closed
-  #   branches:
-  #     - main
-  #   paths:
-  #     - action.yaml
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - main
+    paths:
+      - action.yaml
 jobs:
   release-action:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,12 +1,12 @@
 name: Release
-on:
-  pull_request:
-    types:
-      - closed
-    branches:
-      - main
-    paths:
-      - action.yaml
+on: [push]
+  # pull_request:
+  #   types:
+  #     - closed
+  #   branches:
+  #     - main
+  #   paths:
+  #     - action.yaml
 jobs:
   release-action:
     runs-on: ubuntu-latest

--- a/action.yaml
+++ b/action.yaml
@@ -26,7 +26,7 @@ runs:
   using: "composite"
   steps:
     - name: Build and push image to ECR
-      uses: catalystsquad/action-build-push-image-ecr@v1
+      uses: atomicfi/action-build-push-image-ecr@v1
       with:
         aws-access-key-id: ${{ inputs.aws-access-key-id }}
         aws-secret-access-key: ${{ inputs.aws-secret-access-key }}


### PR DESCRIPTION
Now that this has been tested to work (see run [here](https://github.com/atomicfi/rpa/actions/runs/2693800215), with a pre-release) we can release this.

For PA-45